### PR TITLE
Simplify `.insert(0, …)` to `.unshift(…)`

### DIFF
--- a/lib/add_magic_comment.rb
+++ b/lib/add_magic_comment.rb
@@ -31,7 +31,7 @@ module AddMagicComment
           end
 
           # set current encoding
-          lines.insert(0, comment + "\n")
+          lines.unshift(comment + "\n")
           count += 1
 
           file.pos = 0


### PR DESCRIPTION
This is simpler and probably faster. It mirrors the existing use of `.shift`.

Docs: [`#unshift`](http://ruby-doc.org/core-2.3.1/Array.html#method-i-unshift), [`#insert`](http://ruby-doc.org/core-2.3.1/Array.html#method-i-insert)
