### PR TITLE
Add a comment about Rubocop's EmptyLineAfterMagicComment Cop

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -25,3 +25,4 @@ Notes:
 - existing frozen_string_literal magic comments are replaced
 - the rest of the file remains unchanged
 - empty files are not touched
+- if using Rubocop, consider turning off {EmptyLineAfterMagicComment}[http://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Layout/EmptyLineAfterMagicComment]

--- a/README.rdoc
+++ b/README.rdoc
@@ -25,4 +25,4 @@ Notes:
 - existing frozen_string_literal magic comments are replaced
 - the rest of the file remains unchanged
 - empty files are not touched
-- if using Rubocop, consider turning off the {EmptyLineAfterMagicComment}[http://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Layout/EmptyLineAfterMagicComment] Cop
+- if using Rubocop, consider disabling the {EmptyLineAfterMagicComment}[http://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Layout/EmptyLineAfterMagicComment] Cop

--- a/README.rdoc
+++ b/README.rdoc
@@ -25,4 +25,4 @@ Notes:
 - existing frozen_string_literal magic comments are replaced
 - the rest of the file remains unchanged
 - empty files are not touched
-- if using Rubocop, consider turning off {EmptyLineAfterMagicComment}[http://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Layout/EmptyLineAfterMagicComment]
+- if using Rubocop, consider turning off the {EmptyLineAfterMagicComment}[http://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Layout/EmptyLineAfterMagicComment] Cop


### PR DESCRIPTION
By default the gem does not add an extra line after the magic comment, which will fail Rubocop analysis due to  [EmptyLineAfterMagicComment](http://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Layout/EmptyLineAfterMagicComment). Can be solved by disabling that cop in `rubocop.yml`:

```
Layout/EmptyLineAfterMagicComment:
  Enabled: false
```