### PR TITLE
Append extra newline as per ruby style guide

### DIFF
--- a/lib/add_magic_comment.rb
+++ b/lib/add_magic_comment.rb
@@ -33,7 +33,7 @@ module AddMagicComment
           end
 
           # set current encoding
-          lines.insert(0, comment + "\n")
+          lines.insert(0, comment + "\n\n")
           count += 1
 
           file.pos = 0

--- a/lib/add_magic_comment.rb
+++ b/lib/add_magic_comment.rb
@@ -28,7 +28,7 @@ module AddMagicComment
           lines = file.readlines
 
           # remove current encoding comment(s)
-          while lines.first && lines.first.match(MAGIC_COMMENT_PATTERN)
+          while lines.first && (lines.first.match(MAGIC_COMMENT_PATTERN) || lines.first.strip == '')
             lines.shift
           end
 


### PR DESCRIPTION
Rubocop wants an extra newline as per [ruby style guide].

[ruby style guide]: https://github.com/bbatsov/ruby-style-guide#magic-comments