### PR TITLE
Support local development

### DIFF
--- a/bin/magic_frozen_string_literal
+++ b/bin/magic_frozen_string_literal
@@ -2,6 +2,6 @@
 
 # A simple tool to prepend magic '# frozen_string_literal: true' comments to multiple ".rb" files
 
-require 'add_magic_comment'
+require_relative '../lib/add_magic_comment'
 
 AddMagicComment.process(ARGV)


### PR DESCRIPTION
Using `require_relative` allows for invoking local `bin/magic_frozen_string_literal` to test changes. 