### PR TITLE
Support extensionless filenames

### DIFF
--- a/lib/add_magic_comment.rb
+++ b/lib/add_magic_comment.rb
@@ -33,7 +33,7 @@ module AddMagicComment
           end
 
           # set current encoding
-          lines.insert(0, comment + "\n")
+          lines.insert(0, comment + "\n\n")
           count += 1
 
           file.pos = 0

--- a/lib/add_magic_comment.rb
+++ b/lib/add_magic_comment.rb
@@ -8,9 +8,9 @@ module AddMagicComment
   MAGIC_COMMENT         = "#{MAGIC_COMMENT_PREFIX}: true"
 
   PATTERNS = [
-    {comment: "# #{MAGIC_COMMENT}", extnames: %w[rb rake ru rabl jbuilder]},
-    {comment: "-# #{MAGIC_COMMENT}", extnames: %w[haml slim]},
-    {comment: "<%# #{MAGIC_COMMENT} %>", extnames: %w[erb]},
+    {comment: "# #{MAGIC_COMMENT}", filename_patterns: %w[*.rb *.rake *.ru *.rabl *.jbuilder Gemfile Rakefile]},
+    {comment: "-# #{MAGIC_COMMENT}", filename_patterns: %w[*.haml *.slim]},
+    {comment: "<%# #{MAGIC_COMMENT} %>", filename_patterns: %w[erb]},
   ].freeze
 
   def self.process(argv)
@@ -19,9 +19,8 @@ module AddMagicComment
     count = 0
     PATTERNS.each do |pattern|
       comment = pattern[:comment]
-      pattern[:extnames].each do |ext|
-        filename_pattern = File.join(directory, "**", "*.#{ext}")
-        Dir.glob(filename_pattern).each do |filename|
+      pattern[:filename_patterns].each do |filename_pattern|
+        Dir[File.join(directory, "**", filename_pattern)].each do |filename|
           next unless File.size(filename) > 0
           File.open(filename, "r+") do |file|
             lines = file.readlines

--- a/lib/add_magic_comment.rb
+++ b/lib/add_magic_comment.rb
@@ -28,7 +28,7 @@ module AddMagicComment
           lines = file.readlines
 
           # remove current encoding comment(s)
-          while lines.first && lines.first.match(MAGIC_COMMENT_PATTERN)
+          while lines.first && (lines.first.match(MAGIC_COMMENT_PATTERN) || lines.first.strip == '')
             lines.shift
           end
 

--- a/lib/add_magic_comment.rb
+++ b/lib/add_magic_comment.rb
@@ -8,7 +8,7 @@ module AddMagicComment
   MAGIC_COMMENT         = "#{MAGIC_COMMENT_PREFIX}: true"
 
   PATTERNS = [
-    {comment: "# #{MAGIC_COMMENT}", extnames: %w[rb rake rabl jbuilder]},
+    {comment: "# #{MAGIC_COMMENT}", extnames: %w[rb rake ru rabl jbuilder]},
     {comment: "-# #{MAGIC_COMMENT}", extnames: %w[haml slim]},
     {comment: "<%# #{MAGIC_COMMENT} %>", extnames: %w[erb]},
   ].freeze

--- a/lib/add_magic_comment.rb
+++ b/lib/add_magic_comment.rb
@@ -7,39 +7,38 @@ module AddMagicComment
   MAGIC_COMMENT_PATTERN = /^(-|(<%))?#\s*#{MAGIC_COMMENT_PREFIX}\s*(%>)?/
   MAGIC_COMMENT         = "#{MAGIC_COMMENT_PREFIX}: true"
 
-  EXTENSION_COMMENTS = {
-    "rb"   => "# #{MAGIC_COMMENT}",
-    "rake" => "# #{MAGIC_COMMENT}",
-    "rabl" => "# #{MAGIC_COMMENT}",
-    "jbuilder" => "# #{MAGIC_COMMENT}",
-    "haml" => "-# #{MAGIC_COMMENT}",
-    "slim" => "-# #{MAGIC_COMMENT}",
-    "erb"  => "<%# #{MAGIC_COMMENT} %>"
-  }
+  PATTERNS = [
+    {comment: "# #{MAGIC_COMMENT}", extnames: %w[rb rake rabl jbuilder]},
+    {comment: "-# #{MAGIC_COMMENT}", extnames: %w[haml slim]},
+    {comment: "<%# #{MAGIC_COMMENT} %>", extnames: %w[erb]},
+  ].freeze
 
   def self.process(argv)
     directory = argv.first || Dir.pwd
 
     count = 0
-    EXTENSION_COMMENTS.each do |ext, comment|
-      filename_pattern = File.join(directory, "**", "*.#{ext}")
-      Dir.glob(filename_pattern).each do |filename|
-        next unless File.size(filename) > 0
-        File.open(filename, "r+") do |file|
-          lines = file.readlines
+    PATTERNS.each do |pattern|
+      comment = pattern[:comment]
+      pattern[:extnames].each do |ext|
+        filename_pattern = File.join(directory, "**", "*.#{ext}")
+        Dir.glob(filename_pattern).each do |filename|
+          next unless File.size(filename) > 0
+          File.open(filename, "r+") do |file|
+            lines = file.readlines
 
-          # remove current encoding comment(s)
-          while lines.first && (lines.first.match(MAGIC_COMMENT_PATTERN) || lines.first.strip == '')
-            lines.shift
+            # remove current encoding comment(s)
+            while lines.first && (lines.first.match(MAGIC_COMMENT_PATTERN) || lines.first.strip == '')
+              lines.shift
+            end
+
+            # set current encoding
+            lines.insert(0, comment + "\n\n")
+            count += 1
+
+            file.pos = 0
+            file.puts(lines.join)
+            file.truncate(file.pos)
           end
-
-          # set current encoding
-          lines.insert(0, comment + "\n\n")
-          count += 1
-
-          file.pos = 0
-          file.puts(lines.join)
-          file.truncate(file.pos)
         end
       end
     end


### PR DESCRIPTION
Context
--

Some files which should have magic comments inserted are missed, namely:

* `Gemfile` and `Rakefile` (since they don't have a `.rb` extension; and
* `config.ru`.

Changes
--

* Refactor patterns to an array of hashes (this was to allow for additional config keys but it turned out that two were enough). 
* Add support for Rack file (`*.ru`).
* Add support for `Gemfile` and `Rakefile`. 