### PR TITLE
Leave the original newline code

### DIFF
--- a/lib/add_magic_comment.rb
+++ b/lib/add_magic_comment.rb
@@ -10,28 +10,27 @@ module AddMagicComment
   SHEBANG_PATTERN       = /^#!/
 
   EXTENSION_COMMENTS = {
-    "*.rb"        => ["# #{MAGIC_COMMENT}", 2],
-    "*.ru"        => ["# #{MAGIC_COMMENT}", 2],
-    "Gemfile"     => ["# #{MAGIC_COMMENT}", 2],
-    "Rakefile"    => ["# #{MAGIC_COMMENT}", 2],
-    "*.rake"      => ["# #{MAGIC_COMMENT}", 2],
-    "*.rabl"      => ["# #{MAGIC_COMMENT}", 2],
-    "*.jbuilder"  => ["# #{MAGIC_COMMENT}", 2],
-    "*.haml"      => ["-# #{MAGIC_COMMENT}", 1],
-    "*.slim"      => ["-# #{MAGIC_COMMENT}", 1]
+    "*.rb"        => "# #{MAGIC_COMMENT}\n\n",
+    "*.ru"        => "# #{MAGIC_COMMENT}\n\n",
+    "Gemfile"     => "# #{MAGIC_COMMENT}\n\n",
+    "Rakefile"    => "# #{MAGIC_COMMENT}\n\n",
+    "*.rake"      => "# #{MAGIC_COMMENT}\n\n",
+    "*.rabl"      => "# #{MAGIC_COMMENT}\n\n",
+    "*.jbuilder"  => "# #{MAGIC_COMMENT}\n\n",
+    "*.haml"      => "-# #{MAGIC_COMMENT}\n",
+    "*.slim"      => "-# #{MAGIC_COMMENT}\n"
   }
 
   def self.process(argv)
     directory = argv.first || Dir.pwd
 
     count = 0
-    EXTENSION_COMMENTS.each do |pattern, (comment, num_nl_codes)|
+    EXTENSION_COMMENTS.each do |pattern, comment|
       filename_pattern = File.join(directory, "**", "#{pattern}")
       Dir.glob(filename_pattern).each do |filename|
         File.open(filename, "rb+") do |file|
-          contents = file.read
-          nl_code = detect_nl_code(contents)
-          lines = contents.lines(nl_code)
+          lines = file.readlines
+          newline = detect_newline(lines.first)
           next unless lines.any?
           count += 1
 
@@ -45,7 +44,7 @@ module AddMagicComment
           end
 
           # add magic comment as the first line
-          lines.unshift("#{comment}#{nl_code * num_nl_codes}")
+          lines.unshift(comment.gsub("\n", newline))
 
           # put shebang back
           if shebang
@@ -62,11 +61,7 @@ module AddMagicComment
     puts "Magic comments added to #{count} source file(s)"
   end
 
-  def self.detect_nl_code(contents)
-    if /(\R)/ =~ contents
-      $1
-    else
-      $/
-    end
+  def self.detect_newline(line)
+    (line[/\R/] if line) || $/
   end
 end

--- a/lib/add_magic_comment.rb
+++ b/lib/add_magic_comment.rb
@@ -10,26 +10,28 @@ module AddMagicComment
   SHEBANG_PATTERN       = /^#!/
 
   EXTENSION_COMMENTS = {
-    "*.rb"        => "# #{MAGIC_COMMENT}\n\n",
-    "*.ru"        => "# #{MAGIC_COMMENT}\n\n",
-    "Gemfile"     => "# #{MAGIC_COMMENT}\n\n",
-    "Rakefile"    => "# #{MAGIC_COMMENT}\n\n",
-    "*.rake"      => "# #{MAGIC_COMMENT}\n\n",
-    "*.rabl"      => "# #{MAGIC_COMMENT}\n\n",
-    "*.jbuilder"  => "# #{MAGIC_COMMENT}\n\n",
-    "*.haml"      => "-# #{MAGIC_COMMENT}\n",
-    "*.slim"      => "-# #{MAGIC_COMMENT}\n"
+    "*.rb"        => ["# #{MAGIC_COMMENT}", 2],
+    "*.ru"        => ["# #{MAGIC_COMMENT}", 2],
+    "Gemfile"     => ["# #{MAGIC_COMMENT}", 2],
+    "Rakefile"    => ["# #{MAGIC_COMMENT}", 2],
+    "*.rake"      => ["# #{MAGIC_COMMENT}", 2],
+    "*.rabl"      => ["# #{MAGIC_COMMENT}", 2],
+    "*.jbuilder"  => ["# #{MAGIC_COMMENT}", 2],
+    "*.haml"      => ["-# #{MAGIC_COMMENT}", 1],
+    "*.slim"      => ["-# #{MAGIC_COMMENT}", 1]
   }
 
   def self.process(argv)
     directory = argv.first || Dir.pwd
 
     count = 0
-    EXTENSION_COMMENTS.each do |pattern, comment|
+    EXTENSION_COMMENTS.each do |pattern, (comment, num_nl_codes)|
       filename_pattern = File.join(directory, "**", "#{pattern}")
       Dir.glob(filename_pattern).each do |filename|
-        File.open(filename, "r+") do |file|
-          lines = file.readlines
+        File.open(filename, "rb+") do |file|
+          contents = file.read
+          nl_code = detect_nl_code(contents)
+          lines = contents.lines(nl_code)
           next unless lines.any?
           count += 1
 
@@ -43,7 +45,7 @@ module AddMagicComment
           end
 
           # add magic comment as the first line
-          lines.unshift(comment)
+          lines.unshift("#{comment}#{nl_code * num_nl_codes}")
 
           # put shebang back
           if shebang
@@ -51,12 +53,20 @@ module AddMagicComment
           end
 
           file.pos = 0
-          file.puts(lines.join)
+          file.print(*lines)
           file.truncate(file.pos)
         end
       end
     end
 
     puts "Magic comments added to #{count} source file(s)"
+  end
+
+  def self.detect_nl_code(contents)
+    if /(\R)/ =~ contents
+      $1
+    else
+      $/
+    end
   end
 end

--- a/spec/acceptance_spec.rb
+++ b/spec/acceptance_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path('../lib/add_magic_comment.rb', __dir__)
+require_relative '../lib/add_magic_comment.rb'
 
 RSpec.describe "acceptance" do
   before { setup_test_files }

--- a/spec/newline_code_spec.rb
+++ b/spec/newline_code_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path('../lib/add_magic_comment.rb', __dir__)
+require_relative '../lib/add_magic_comment.rb'
 
 RSpec.describe "newline code" do
   before { setup_test_files }

--- a/spec/newline_code_spec.rb
+++ b/spec/newline_code_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require File.expand_path('../lib/add_magic_comment.rb', __dir__)
+
+RSpec.describe "newline code" do
+  before { setup_test_files }
+  after { teardown_test_files }
+
+  let(:test_directory) do
+    File.expand_path('../tmp/test', __dir__)
+  end
+
+  let(:nl_codes) do
+    { lf: "\n", crlf: "\r\n", cr: "\r" }
+  end
+
+  let(:test_files) do
+    nl_codes
+      .keys
+      .map { |nl_name| [nl_name, File.join(test_directory, "#{nl_name}.rb")] }
+      .to_h
+  end
+
+  it "leaves newline code as it is", :aggregate_failures do
+    AddMagicComment.process([test_directory])
+    nl_codes.each do |nl_name, nl_code|
+      expected = ["# frozen_string_literal: true", "", "foo", "bar"].join(nl_code)
+      actual = File.binread(test_files[nl_name])
+      expect(actual).to eq(expected), <<~ERROR
+        Expected newline code to be leaved as it is but it was changed.
+
+        Expected:
+        #{expected.inspect}
+
+        Actual:
+        #{actual.inspect}
+      ERROR
+    end
+  end
+
+  def setup_test_files
+    FileUtils.mkdir_p(test_directory)
+    nl_codes.each do |nl_name, nl_code|
+      setup_test_file(nl_name, nl_code)
+    end
+  end
+
+  def setup_test_file(nl_name, nl_code)
+    File.binwrite(test_files[nl_name], "foo#{nl_code}bar")
+  end
+
+  def teardown_test_files
+    FileUtils.rm_rf(test_directory)
+  end
+end

--- a/spec/newline_code_spec.rb
+++ b/spec/newline_code_spec.rb
@@ -10,22 +10,22 @@ RSpec.describe "newline code" do
     File.expand_path('../tmp/test', __dir__)
   end
 
-  let(:nl_codes) do
+  let(:newlines) do
     { lf: "\n", crlf: "\r\n", cr: "\r" }
   end
 
   let(:test_files) do
-    nl_codes
+    newlines
       .keys
-      .map { |nl_name| [nl_name, File.join(test_directory, "#{nl_name}.rb")] }
+      .map { |newline_name| [newline_name, File.join(test_directory, "#{newline_name}.rb")] }
       .to_h
   end
 
   it "leaves newline code as it is", :aggregate_failures do
     AddMagicComment.process([test_directory])
-    nl_codes.each do |nl_name, nl_code|
-      expected = ["# frozen_string_literal: true", "", "foo", "bar"].join(nl_code)
-      actual = File.binread(test_files[nl_name])
+    newlines.each do |newline_name, newline|
+      expected = ["# frozen_string_literal: true", "", "foo", "bar"].join(newline)
+      actual = File.binread(test_files[newline_name])
       expect(actual).to eq(expected), <<~ERROR
         Expected newline code to be leaved as it is but it was changed.
 
@@ -40,13 +40,13 @@ RSpec.describe "newline code" do
 
   def setup_test_files
     FileUtils.mkdir_p(test_directory)
-    nl_codes.each do |nl_name, nl_code|
-      setup_test_file(nl_name, nl_code)
+    newlines.each do |newline_name, newline|
+      setup_test_file(newline_name, newline)
     end
   end
 
-  def setup_test_file(nl_name, nl_code)
-    File.binwrite(test_files[nl_name], "foo#{nl_code}bar")
+  def setup_test_file(newline_name, newline)
+    File.binwrite(test_files[newline_name], "foo#{newline}bar")
   end
 
   def teardown_test_files


### PR DESCRIPTION
Due to #27, newline codes will be replaced with the standard newline code for the platform.

* Platform: Windows Original newline code LF:
    * All of newline codes will replaced with CR-LF
* Platform: Linux Original newline code CR-LF:
    * All of newline codes will replaced with LF

To fix this problem, I changed:

* File opening mode: text mode -> binary mode
* Newline code for the magic comment: `\n` -> newline code detected from the file
