### PR TITLE
Add processing of selected paths only

### DIFF
--- a/bin/magic_frozen_string_literal
+++ b/bin/magic_frozen_string_literal
@@ -3,5 +3,19 @@
 # A simple tool to prepend magic '# frozen_string_literal: true' comments to multiple ".rb" files
 
 require_relative '../lib/add_magic_comment'
+require "optparse"
 
-AddMagicComment.process(ARGV)
+process_files = false
+OptionParser.new do |opts|
+  opts.banner = "Usage: magic_frozen_string_literal app/ lib/"
+
+  opts.on("-f", "--files", "Apply to specific files instead of files in directories") do |v|
+    process_files = true
+  end
+end.parse!
+
+if process_files
+  AddMagicComment.process_files_at(ARGV)
+else
+  AddMagicComment.process(ARGV)
+end

--- a/spec/fixtures/expected/shebang_already_commented.rb
+++ b/spec/fixtures/expected/shebang_already_commented.rb
@@ -1,3 +1,4 @@
 #!/usr/bin/ruby
+# frozen_string_literal: true
 
 puts "hello"

--- a/spec/fixtures/input/Gemfile
+++ b/spec/fixtures/input/Gemfile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 source 'https://rubygems.org'
 
 gem 'magic_frozen_string_literal'

--- a/spec/fixtures/input/Rakefile
+++ b/spec/fixtures/input/Rakefile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "bundler/gem_tasks"
 
 task :test do

--- a/spec/fixtures/input/blank_line.rb
+++ b/spec/fixtures/input/blank_line.rb
@@ -1,3 +1,1 @@
-# frozen_string_literal: true
-
 puts "hello"

--- a/spec/fixtures/input/config.ru
+++ b/spec/fixtures/input/config.ru
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is used by Rack-based servers to start the application.
 
 require_relative 'config/environment'

--- a/spec/fixtures/input/shebang_already_commented.rb
+++ b/spec/fixtures/input/shebang_already_commented.rb
@@ -1,3 +1,4 @@
 #!/usr/bin/ruby
+# frozen_string_literal: true
 
 puts "hello"

--- a/spec/fixtures/input/shebang_blank_line.rb
+++ b/spec/fixtures/input/shebang_blank_line.rb
@@ -1,4 +1,3 @@
 #!/usr/bin/ruby
-# frozen_string_literal: true
 
 puts "hello"

--- a/spec/fixtures/input/t1.haml
+++ b/spec/fixtures/input/t1.haml
@@ -1,2 +1,1 @@
--# frozen_string_literal: true
 <b>Hello!</b>

--- a/spec/fixtures/input/t1.rb
+++ b/spec/fixtures/input/t1.rb
@@ -1,3 +1,1 @@
-# frozen_string_literal: true
-
 puts "hello"

--- a/spec/fixtures/input/t1.slim
+++ b/spec/fixtures/input/t1.slim
@@ -1,2 +1,1 @@
--# frozen_string_literal: true
 <b>Hello!</b>

--- a/spec/fixtures/input/utf8.rb
+++ b/spec/fixtures/input/utf8.rb
@@ -1,3 +1,1 @@
-# frozen_string_literal: true
-
 puts " "


### PR DESCRIPTION
This is useful when you feed a list of files which have been touched in a Git branch, and get fed to the script using xargs. There is no point processing the entire codebase every time the script runs and specifying paths speeds things up considerably, especially on large codebases.

Change tests to actually ensure the magic comment gets added (input files already had one)